### PR TITLE
Added partner biographies to menu

### DIFF
--- a/config/menus/dapaas.yml
+++ b/config/menus/dapaas.yml
@@ -19,6 +19,9 @@
     title: "Partners"
     link: "/dapaas-partners"
    -
+    title: "Partner Biographies"
+    link: "/dapaas-partner-biographies"
+   -
     title: "Links"
     link: "/dapaas-links"
    -


### PR DESCRIPTION
Add dapaas-partner-biographies to menu item. Needs content in panopticon
