### PR TITLE
Change opacity of images on hover

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -645,16 +645,24 @@ hr {
       }
 
     &.module-image-fullbleed {
+
+        &:hover {
+          .image {
+            opacity: 0.6;
+          }
+        }
+
         padding: 0;
         img {
-            max-width: none;
-            max-height: none;
+          max-width: none;
+          max-height: none;
         }
 
         .text {
           position: absolute;
-          top: 25px;
-          left: 25px;
+          top: 0;
+          padding: 25px;
+          height: 100%;
         }
 
         .background--light {
@@ -662,7 +670,7 @@ hr {
         }
 
         .background--dark {
-          color: #eee;
+          color: #fff;
         }
       }
 


### PR DESCRIPTION
When users hover over modules with images, the image changes opacity, like so:

Normal state:

![screenshot 2014-04-03 20 29 44](https://cloud.githubusercontent.com/assets/109774/2608064/6fcf7efe-bb66-11e3-99e3-cab4f839875a.png)

Hover state:

![screenshot 2014-04-03 20 29 47](https://cloud.githubusercontent.com/assets/109774/2608066/765f5df2-bb66-11e3-8cd7-426cf9b6c86e.png)
