### PR TITLE
Add font_assets gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,3 +42,4 @@ gem 'plek', '~> 1.7'
 gem 'jasmine', '1.1.2'
 
 gem 'govuk_frontend_toolkit', '0.31.0'
+gem 'font_assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
     ffi (1.9.3)
     font-awesome-rails (4.0.3.1)
       railties (>= 3.2, < 5.0)
+    font_assets (0.1.11)
+      rack
     foreman (0.63.0)
       dotenv (>= 0.7)
       thor (>= 0.13.6)
@@ -183,6 +185,7 @@ DEPENDENCIES
   dotenv-rails
   exception_notification (~> 2.6.1)
   font-awesome-rails
+  font_assets
   foreman
   govuk_frontend_toolkit (= 0.31.0)
   jasmine (= 1.1.2)


### PR DESCRIPTION
So this will fix all the cross origin font weirdness, which (I think) is only an issue on Dapaas
