### PR TITLE
Adding grid-sizer class

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -462,7 +462,7 @@ hr {
 
 }
 
-.home-module {
+.home-module, .grid-sizer {
 
     list-style: none;
     @include box-sizing(border-box);
@@ -946,7 +946,7 @@ hr {
 
 .people-team {
 
-    .home-module {
+    .home-module, .grid-sizer {
 
         @media (min-width: 992px) {
 


### PR DESCRIPTION
This is required to make the adaptive filtering work on the team page.
.grid-sizer changes in line with the .home-module element, and is used
as a reference to resize the Masonry grid