### PR TITLE
Remove Navbar Search form

### DIFF
--- a/app/assets/stylesheets/bootstrap/_navbar.scss
+++ b/app/assets/stylesheets/bootstrap/_navbar.scss
@@ -272,6 +272,7 @@
 // our navbars.
 
 .navbar-form {
+  display: none;
   margin-left: -$navbar-padding-horizontal;
   margin-right: -$navbar-padding-horizontal;
   padding: 10px $navbar-padding-horizontal;


### PR DESCRIPTION
The search function in the navgiation bar has ceased to work. Initial removal of the feature
before implementing a working version.

Simple 'display:none' on the search form